### PR TITLE
Fix #28 Default `activeClass` option

### DIFF
--- a/src/ScrollSpy.js
+++ b/src/ScrollSpy.js
@@ -33,7 +33,7 @@ class ScrollSpy {
             targetSelector: options.targetSelector || 'a',
             offset: options.offset || 0,
             hrefAttribute: options.hrefAttribute || 'href',
-            activeClass: options.activeClass.trim().split(' ') || ['active'],
+            activeClass: options.activeClass?.trim().split(' ') || ['active'],
             onActive: options.onActive || null,
         };
         this.sections = document.querySelectorAll(this.options.sectionSelector);


### PR DESCRIPTION
If no `activeClass` option is provided it break when trying to run trim on null.

Use nullsafe to fix & trigger defaults